### PR TITLE
Bugfix where using object initializer syntax does not set layout propert...

### DIFF
--- a/XibFree/UILayoutHostScrollable.cs
+++ b/XibFree/UILayoutHostScrollable.cs
@@ -60,7 +60,7 @@ namespace XibFree
 
 			set
 			{
-				_layoutHost.Layout = Layout;
+				_layoutHost.Layout = value;
 				SetNeedsLayout();
 			}
 		}
@@ -91,6 +91,7 @@ namespace XibFree
 				ContentSize = size;
 			}
 		}
+
 	}
 }
 


### PR DESCRIPTION
...y correctly

Using the format:

...
new UILayoutHostScrollable()
{
    Layout = someLayout
}
...

would result in the layout not loading properly. It did, however, work perfect using the method argument syntax.
